### PR TITLE
fix the generation of the service token

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -32,6 +32,7 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/commons-lang/commons-lang/2.6/commons-lang-2.6.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/io/vertx/vertx-dropwizard-metrics/3.5.1/vertx-dropwizard-metrics-3.5.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/io/dropwizard/metrics/metrics-core/4.0.2/metrics-core-4.0.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/life/genny/qwanda-utils/2.0.0/qwanda-utils-2.0.0.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/javamoney/moneta/1.1/moneta-1.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/javax/money/money-api/1.0.1/money-api-1.0.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar" enabled="true" runInBatchMode="false"/>
@@ -66,6 +67,13 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/json/json/20170516/json-20170516.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/keycloak/keycloak-adapter-core/3.4.0.Final/keycloak-adapter-core-3.4.0.Final.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/keycloak/keycloak-adapter-spi/3.4.0.Final/keycloak-adapter-spi-3.4.0.Final.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/keycloak/keycloak-core/3.4.0.Final/keycloak-core-3.4.0.Final.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/keycloak/keycloak-common/3.4.0.Final/keycloak-common-3.4.0.Final.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/bouncycastle/bcprov-jdk15on/1.56/bcprov-jdk15on-1.56.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/bouncycastle/bcpkix-jdk15on/1.56/bcpkix-jdk15on-1.56.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/keycloak/keycloak-admin-client/3.4.0.Final/keycloak-admin-client-3.4.0.Final.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/jboss/resteasy/resteasy-multipart-provider/3.0.4.Final/resteasy-multipart-provider-3.0.4.Final.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/jboss/resteasy/resteasy-jaxrs/3.0.4.Final/resteasy-jaxrs-3.0.4.Final.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/jboss/resteasy/jaxrs-api/3.0.4.Final/jaxrs-api-3.0.4.Final.jar" enabled="true" runInBatchMode="false"/>
@@ -275,5 +283,4 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/stax/stax-api/1.0.1/stax-api-1.0.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/io/vavr/vavr/0.9.1/vavr-0.9.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/io/vavr/vavr-match/0.9.1/vavr-match-0.9.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="PLUGIN" id="org.eclipse.jst.ws.annotations.core" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/.project
+++ b/.project
@@ -20,9 +20,6 @@
       <name>org.jboss.tools.jst.web.kb.kbbuilder</name>
     </buildCommand>
     <buildCommand>
-      <name>org.jboss.tools.cdi.core.cdibuilder</name>
-    </buildCommand>
-    <buildCommand>
       <name>org.eclipse.wst.validation.validationbuilder</name>
     </buildCommand>
     <buildCommand>
@@ -41,6 +38,5 @@
     <nature>org.hibernate.eclipse.console.hibernateNature</nature>
     <nature>org.eclipse.wst.common.project.facet.core.nature</nature>
     <nature>org.jboss.tools.jst.web.kb.kbnature</nature>
-    <nature>org.jboss.tools.cdi.core.cdinature</nature>
   </natures>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -2,7 +2,10 @@
 <projectDescription>
   <name>genny-verticle-rules</name>
   <comment>NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
-  <projects/>
+  <projects>
+    <project>qwanda-utils</project>
+    <project>qwanda</project>
+  </projects>
   <buildSpec>
     <buildCommand>
       <name>org.eclipse.wst.common.project.facet.core.builder</name>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,5 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.processAnnotations=enabled
-org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/src/main/java/life/genny/utils/RulesUtils.java
+++ b/src/main/java/life/genny/utils/RulesUtils.java
@@ -181,33 +181,6 @@ public class RulesUtils {
 
 	public static String generateServiceToken(String realm) {
 
-		// check if already in cache
-		String serviceToken = VertxUtils.getObject(realm, "CACHE", "SERVICE_TOKEN", String.class);
-		// TODO check expiry date
-		if (serviceToken != null) {
-		//	println("Fetching Service Token for " + realm + " from cache :"
-		//			+ StringUtils.abbreviateMiddle(serviceToken, "...", 20));
-			// check expiry date
-			JSONObject decodedServiceToken = KeycloakUtils.getDecodedToken(serviceToken);
-			long expiryTime = decodedServiceToken.getLong("exp");
-			long nowTime = LocalDateTime.now().atZone(TimeZone.getDefault().toZoneId()).toEpochSecond();
-			long duration = expiryTime - nowTime;
-			LocalDateTime expiryDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(expiryTime),
-					TimeZone.getDefault().toZoneId());
-
-			LocalDateTime nowDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(nowTime),
-					TimeZone.getDefault().toZoneId());
-
-		//	println("JWT Expiry Time = " + expiryTime + " (" + expiryDateTime.toString() + ") and now Time (UMT) = "
-		//			+ nowTime + " (" + nowDateTime.toString() + ")  diff (secs to expiry) = " + duration + " sec");
-			if (nowDateTime.isAfter(expiryDateTime)) {
-				log.info("Service Token Expired! - generate new one!");
-				serviceToken = null;
-			} else {
-				return serviceToken;
-			}
-		}
-
 		println("Generating Service Token for " + realm);
 
 		String jsonFile = realm + ".json";

--- a/src/main/java/life/genny/utils/RulesUtils.java
+++ b/src/main/java/life/genny/utils/RulesUtils.java
@@ -180,93 +180,62 @@ public class RulesUtils {
 	}
 
 	public static String generateServiceToken(String realm) {
-
-		// check if already in cache
-		String serviceToken = VertxUtils.getObject(realm, "CACHE", "SERVICE_TOKEN", String.class);
-		// TODO check expiry date
-		if (serviceToken != null) {
-		//	println("Fetching Service Token for " + realm + " from cache :"
-		//			+ StringUtils.abbreviateMiddle(serviceToken, "...", 20));
-			// check expiry date
-			JSONObject decodedServiceToken = KeycloakUtils.getDecodedToken(serviceToken);
-			long expiryTime = decodedServiceToken.getLong("exp");
-			long nowTime = LocalDateTime.now().atZone(TimeZone.getDefault().toZoneId()).toEpochSecond();
-			long duration = expiryTime - nowTime;
-			LocalDateTime expiryDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(expiryTime),
-					TimeZone.getDefault().toZoneId());
-
-			LocalDateTime nowDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(nowTime),
-					TimeZone.getDefault().toZoneId());
-
-		//	println("JWT Expiry Time = " + expiryTime + " (" + expiryDateTime.toString() + ") and now Time (UMT) = "
-		//			+ nowTime + " (" + nowDateTime.toString() + ")  diff (secs to expiry) = " + duration + " sec");
-			if (nowDateTime.isAfter(expiryDateTime)) {
-				log.info("Service Token Expired! - generate new one!");
-				serviceToken = null;
-			} else {
-				return serviceToken;
-			}
-		}
-
-		println("Generating Service Token for " + realm);
-
-		String jsonFile = realm + ".json";
-
+        
+		println("Generating Service Token for "+realm);
+		String jsonFile = realm + ".json";        
 		String keycloakJson = SecureResources.getKeycloakJsonMap().get(jsonFile);
 		if (keycloakJson == null) {
-			println("No keycloakMap for " + realm + " ... fixing");
+			println("No keycloakMap for " + realm+" ... fixing");
 			SecureResources.readFilenamesFromDirectory(GennySettings.realmDir);
 			String gennyKeycloakJson = SecureResources.getKeycloakJsonMap().get("genny.json");
 			if (GennySettings.devMode) {
-				SecureResources.getKeycloakJsonMap().put(jsonFile, gennyKeycloakJson);
-				keycloakJson = gennyKeycloakJson;
-			} else {
-				if (GennySettings.defaultLocalIP.equalsIgnoreCase(GennySettings.hostIP)) {
-					println("gennyKeycloakJson=" + gennyKeycloakJson);
-					// Running in local docker mode
 					SecureResources.getKeycloakJsonMap().put(jsonFile, gennyKeycloakJson);
 					keycloakJson = gennyKeycloakJson;
-					println("No keycloak Json file available for realm - " + realm + " , so using genny instead ..");
-				} else {
-					println("Error - No keycloak Json file available for realm - " + realm);
-				}
+			} else {
+					if (GennySettings.defaultLocalIP.equalsIgnoreCase(GennySettings.hostIP)) {
+							println("gennyKeycloakJson="+gennyKeycloakJson);
+							// Running in local docker mode
+							SecureResources.getKeycloakJsonMap().put(jsonFile, gennyKeycloakJson);
+							keycloakJson = gennyKeycloakJson;
+							println("No keycloak Json file available for realm - "+realm+" , so using genny instead ..");
+					} else {
+							println("Error - No keycloak Json file available for realm - "+realm);
+					}
 			}
 		}
-		println("keycloak.json=" + keycloakJson);
+		println("keycloak.json="+keycloakJson);
 		JsonObject realmJson = new JsonObject(keycloakJson);
 		JsonObject secretJson = realmJson.getJsonObject("credentials");
 		String secret = secretJson.getString("secret");
 		String jsonRealm = realmJson.getString("realm");
-
+		
 		String key = GennySettings.dynamicKey(jsonRealm);
 		String initVector = GennySettings.dynamicInitVector(jsonRealm);
 		String encryptedPassword = GennySettings.dynamicEncryptedPassword(jsonRealm);
-		String password = null;
+		String password= null;
 		String dynamicRealm = GennySettings.dynamicRealm(jsonRealm);
-
-		println("key:" + key + ":" + initVector + ":" + encryptedPassword);
+		
+		println("key:"+key+":"+initVector+":"+encryptedPassword);
 		password = GennySettings.dynamicPassword(jsonRealm);
-
-		println("password=[" + password + "]");
-
+		println("password=["+password+"]");
 		// Now ask the bridge for the keycloak to use
 		String keycloakurl = realmJson.getString("auth-server-url").substring(0,
-				realmJson.getString("auth-server-url").length() - ("/auth".length()));
-
+						realmJson.getString("auth-server-url").length() - ("/auth".length()));
 		println(keycloakurl);
-
 		try {
-			println("jsonRealm= " + jsonRealm + ", dynamicRealm() : " + dynamicRealm + "\n" + "realm : " + realm + "\n"
-					+ "secret : " + secret + "\n" + "keycloakurl: " + keycloakurl + "\n" + "key : " + key + "\n"
-					+ "initVector : " + initVector + "\n" + "enc pw : " + encryptedPassword + "\n" + "password : ["
-					+ password + "]\n");
+			println("jsonRealm= "+jsonRealm+", dynamicRealm() : " + dynamicRealm + "\n" + "realm : " + realm + "\n" + "secret : " + secret + "\n"
+							+ "keycloakurl: " + keycloakurl + "\n" + "key : " + key + "\n" + "initVector : " + initVector + "\n"
+							+ "enc pw : " + encryptedPassword + "\n" + "password : [" + password + "]\n");
+
+			/* we get the refresh token from the cache */
+			String cached_refresh_token = VertxUtils.getObject(realm, "CACHE", "SERVICE_TOKEN_REFRESH", String.class); 
 
 			/* we get a secure token payload containing a refresh token and an access token */
-			JsonObject secureTokenPayload = KeycloakUtils.getSecureTokenPayload(keycloakurl, dynamicRealm, dynamicRealm, secret, "service", password);
+			JsonObject secureTokenPayload = KeycloakUtils.getSecureTokenPayload(keycloakurl, dynamicRealm, dynamicRealm, secret, "service", password, cached_refresh_token);
 
 			/* we get the access token and the refresh token */
 			String access_token = secureTokenPayload.getString("access_token");
-			String refresh_token = secureTokenPayload.getString("access_token");
+			String refresh_token = secureTokenPayload.getString("refresh_token");
 
 			/* we print it out */
 			println("access_token = " + StringUtils.abbreviateMiddle(access_token, "...", 20));
@@ -284,13 +253,11 @@ public class RulesUtils {
 				VertxUtils.putObject(realm, "CACHE", "SERVICE_TOKEN", access_token); // TODO
 				VertxUtils.putObject(realm, "CACHE", "SERVICE_TOKEN_REFRESH", refresh_token); // TODO
 			}
-
 			return access_token;
 
 		} catch (Exception e) {
-			println(e);
+				println(e);
 		}
-
 		return null;
 	}
 

--- a/src/main/java/life/genny/utils/RulesUtils.java
+++ b/src/main/java/life/genny/utils/RulesUtils.java
@@ -200,9 +200,11 @@ public class RulesUtils {
 			long duration = expiryTime - nowTime;
 
 			/* if the difference is negative it means the expiry time is less than the nowTime 
-				 if the difference < 180000, it means the token will expire in 3 hours
+				 if the difference < ACCESS_TOKEN_EXPIRY_LIMIT_SECONDS, it means the token will expire in 3 hours
 			*/
-			if(duration >= 10800) {
+			if(duration > GennySettings.ACCESS_TOKEN_EXPIRY_LIMIT_SECONDS) {
+
+				System.out.println("======= USING CACHED ACCESS TOKEN ========");
 
 				/* if the token is NOTn about to expire (> 3 hours), we reuse it */
 				return serviceToken;
@@ -281,9 +283,6 @@ public class RulesUtils {
 			else {
 				VertxUtils.putObject(realm, "CACHE", "SERVICE_TOKEN", access_token); // TODO
 				VertxUtils.putObject(realm, "CACHE", "SERVICE_TOKEN_REFRESH", refresh_token); // TODO
-				
-				/* we pause just to be certain the tokens have been cached. not great but vertxutils is causing issues. */ 
-				Thread.sleep(5000);
 			}
 						
 			return access_token;


### PR DESCRIPTION
Issue: https://outcomelife.atlassian.net/browse/GEN-1391

### Bug Description:

It looks like the service token was grabbed from the cache before. This was to prevent having to create a new session every time, but it is actually creating lots of issues as the service token is not refreshed when it needs to be. This is a rollback to creating a new session every time for now.

### How To Test:

On internmatch, try to create a new internship. Most of the dropdowns with multiple selections will be empty. that's because the backend rules use the SearchEntity to get the relevant data using the service token. because the service token has expired, no data is showing in the dropdown.

### Dependency: 

https://github.com/genny-project/qwanda-utils/pulls
