### PR TITLE
Added method for remove base entity service

### DIFF
--- a/src/main/java/life/genny/utils/BaseEntityUtils.java
+++ b/src/main/java/life/genny/utils/BaseEntityUtils.java
@@ -1525,6 +1525,17 @@ public class BaseEntityUtils {
 		}
 		return null;
 	}
+	
+	public String removeBaseEntity(final String baseEntityCode) {
+		try {
+			return QwandaUtils.apiDelete(this.qwandaServiceUrl + "/qwanda/baseentitys" + baseEntityCode,
+					this.token);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return "Success";
+
+	}
 
 	/*
 	 * Returns comma seperated list of all the childcode for the given parent code

--- a/src/main/java/life/genny/utils/BaseEntityUtils.java
+++ b/src/main/java/life/genny/utils/BaseEntityUtils.java
@@ -1528,7 +1528,7 @@ public class BaseEntityUtils {
 	
 	public String removeBaseEntity(final String baseEntityCode) {
 		try {
-			return QwandaUtils.apiDelete(this.qwandaServiceUrl + "/qwanda/baseentitys" + baseEntityCode,
+			return QwandaUtils.apiDelete(this.qwandaServiceUrl + "/qwanda/baseentitys/" + baseEntityCode,
 					this.token);
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
# Issue https://outcomelife.atlassian.net/projects/GEN/issues/GEN-1557

# Description:
Create API to delete baseentity and its dependecies from entityattribute, entityentity and answerlinks tables.

# How To Test
1) Get the genny-verticle-rules, qwanda-services and wildfly-qwanda-service code from GEN-1557 branch, build and batchload the application.
2) Get the code of the base entity that you want to delete.
3) Through postman, call the Qwanda API /baseentitys/{code} using HTTP DELETE method. Or modify any rule to delete the baseentity by calling rules.baseEntity.removeBaseEntity("baseEntityCode");
4) Check in database and make sure data are deleted from baseentity and dependent tables. 